### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_team_config_integration.py
+++ b/tests/test_team_config_integration.py
@@ -122,7 +122,12 @@ def test_config_loader_with_team(sample_config_json):
     
     # Check security policy retrieval
     security_policy = config_loader.get_security_policy()
-    assert "github.com" in security_policy.allowed_domains
+    from urllib.parse import urlparse
+    allowed_domains = security_policy.allowed_domains
+    def is_allowed_domain(url):
+        hostname = urlparse(url).hostname
+        return hostname in allowed_domains
+    assert is_allowed_domain("https://github.com")
     assert security_policy.terminal_sandbox.image == "python:3.9-alpine"
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Qredence/Agentic-Kernel/security/code-scanning/3](https://github.com/Qredence/Agentic-Kernel/security/code-scanning/3)

To fix the problem, we need to ensure that the domain check is performed on the parsed hostname of the URL rather than using a substring check. This can be achieved by using the `urlparse` function from the `urllib.parse` module to extract the hostname from the URL and then checking if it matches any of the allowed domains.

1. Parse the URL to extract the hostname.
2. Check if the extracted hostname matches any of the allowed domains.
3. Update the test to use this new method of checking allowed domains.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
